### PR TITLE
Update device : Xiaomi Redmi 7/Y3

### DIFF
--- a/deviceData.json
+++ b/deviceData.json
@@ -193,12 +193,12 @@
     },
     {
         "brand": "Xiaomi",
-        "model": "Xiaomi Redmi 7",
-        "codeName": "onclite",
-        "baseURL": "https://sourceforge.net/projects/shrp/files/onclite/",
+        "model": "Xiaomi Redmi 7/Y3",
+        "codeName": "onc",
+        "baseURL": "https://sourceforge.net/projects/shrp/files/onc/",
         "latestBuild": "https://sourceforge.net/projects/shrp/files/onclite/SHRP_v2.3.2_onclite-155021072020.zip/download",
         "mockSrc": "img/Devices/notch.svg",
-        "maintainer": "hadaddarajat",
+        "maintainer": "TheSync",
         "buildNo": "155021072020",
         "currentVersion": "2.3.2",
         "md5": "0283c040c9e552ad576691d335e4bf6d"


### PR DESCRIPTION
* There are Redmi 7 and Redmi Y3, both are same, only different from specific camera
  Both use same base rom (miui), even same cusrom it can run on both

* Also same kernel source from miui
  https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/onc-q-oss

* Redmi 7 = onclite, Redmi Y3 = onc

* But on miui (stock) use one codename "onc"

* Change codename "onclite" to "onc" so that device release become "Redmi 7/Y3 (onc)"

* Also prepared a new tree for this, also tested on Redmi Y3 by several tester using Y3, and it works

* New device tree
  https://github.com/SHRP-Devices/android_device_xiaomi_onc

* For old builds leave it on SF "onclite" but in future releases it will be SF "onc"